### PR TITLE
Minor fixups in map display for testing

### DIFF
--- a/backend/utils/resource-utils.js
+++ b/backend/utils/resource-utils.js
@@ -21,7 +21,7 @@ const sortByDistance = (a, b, lat, long) => {
 
 const options = {
   shouldSort: true,
-  threshold: 0.5,
+  threshold: 0.2,
   location: 0,
   distance: 100,
   maxPatternLength: 32,

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -6,11 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/frontend/src/components/ResourceCard/styles.scss
+++ b/frontend/src/components/ResourceCard/styles.scss
@@ -2,7 +2,6 @@
     border: solid rgb(201, 194, 194) 2.5px;
     border-radius: 7px;
     background-color: white;
-    width: 100%;
-    height: 100px;
     padding: 5%;
+    margin:10px;
 } 

--- a/frontend/src/pages/MapView/styles.scss
+++ b/frontend/src/pages/MapView/styles.scss
@@ -7,7 +7,7 @@
     left: 25px;
     top: 25px;
     width: 300px;
-    height: 600px;
+    height: 400px;
     z-index: 1;
 }
 


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status:
🚀 
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Addressed a few minor styling and logistic fixups to get search fulling working given a seeded database. More specifically:

- Address a styling issue where resource cards were fixed size so the text all clobbered over each other given the descriptions, so we couldn't read the cards.
- Tuned down sensitivity on fuzzy, since it was returning almost every result every time.

These will be resolved during our restyling revamp, but this is more of a temp fix to be able to manually test the interface.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #<number>

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots
Before:
<img width="1184" alt="Screen Shot 2019-11-18 at 1 00 52 AM" src="https://user-images.githubusercontent.com/8664074/69031096-e6ce8b80-099e-11ea-8619-86ba8a2a9a68.png">
After:
<img width="1166" alt="Screen Shot 2019-11-18 at 1 00 14 AM" src="https://user-images.githubusercontent.com/8664074/69031045-cd2d4400-099e-11ea-89f3-e8291c1ad73c.png">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
