### PR TITLE
Display user role in notification

### DIFF
--- a/frontend/src/utils/apiHelpers.js
+++ b/frontend/src/utils/apiHelpers.js
@@ -2,6 +2,7 @@ import store from "../redux/store";
 import { apiAction } from "../redux/actions/api";
 import { authUpdateAction, authPurgeAction } from "../redux/actions/auth";
 import urljoin from "url-join";
+import { toast } from "react-toastify";
 const R = require("ramda");
 
 const API_URI = process.env.REACT_APP_API_URI
@@ -52,6 +53,9 @@ export const apiRequest = ({
 
 export const updateGlobalAuthState = payload => {
   store.dispatch(authUpdateAction(payload));
+  if (process.env.NODE_ENV === "development") {
+    toast.info(`Logged in with ${payload.role} role!`);
+  }
 };
 
 export const purgeGlobalAuthState = () => {


### PR DESCRIPTION
## Status:

:rocket:

## Description

This modification sends a toast notification with message indicating user role; the notification is only sent in a development environment, not in test nor production.

Fixes #127 

## Screenshots

![toast-user](https://user-images.githubusercontent.com/20096090/74611941-446d9380-50c6-11ea-8e44-6f80553ea1cc.gif)
