### PR TITLE
add a redirection that hides the main page from pending users

### DIFF
--- a/frontend/src/components/PrivateRoute/index.jsx
+++ b/frontend/src/components/PrivateRoute/index.jsx
@@ -2,12 +2,21 @@ import React from "react";
 import { Route, Redirect } from "react-router-dom";
 import Loader from "../Loader";
 import Navbar from "../Navbar";
+import Pending from "../../pages/Pending";
 import { connect } from "react-redux";
+import { roleEnum } from "../../utils/enums";
 
-function PrivateRoute({ component: Component, authed, showLoader, ...rest }) {
+function PrivateRoute({
+  component: Component,
+  authed,
+  role,
+  showLoader,
+  ...rest
+}) {
+  const pending = role === roleEnum.PENDING;
   return (
     <div>
-      {authed && <Navbar />}
+      {!pending && <Navbar />}
       <Route
         {...rest}
         render={props => {
@@ -15,7 +24,10 @@ function PrivateRoute({ component: Component, authed, showLoader, ...rest }) {
             return <Loader></Loader>;
           }
           if (authed === true) {
-            return <Component {...props} />;
+            if (!pending) {
+              return <Component {...props} />;
+            }
+            return <Pending {...props} />;
           }
           if (authed === false) {
             return (
@@ -31,6 +43,7 @@ function PrivateRoute({ component: Component, authed, showLoader, ...rest }) {
 }
 const mapStateToProps = state => ({
   authed: state.auth.authenticated,
+  role: state.auth.role,
   showLoader: state.auth.isFetchingAuth
 });
 

--- a/frontend/src/components/PrivateRoute/index.jsx
+++ b/frontend/src/components/PrivateRoute/index.jsx
@@ -16,7 +16,7 @@ function PrivateRoute({
   const pending = role === roleEnum.PENDING;
   return (
     <div>
-      {!pending && <Navbar />}
+      {authed && !pending && <Navbar />}
       <Route
         {...rest}
         render={props => {

--- a/frontend/src/pages/Pending/index.jsx
+++ b/frontend/src/pages/Pending/index.jsx
@@ -1,9 +1,5 @@
 import React, { Component } from "react";
 
-// import Logo from "./images/lah-logo.png";
-
-import "./styles.scss";
-
 class Pending extends Component {
   render() {
     return <div>lets pretend we dont exist</div>;

--- a/frontend/src/pages/Pending/index.jsx
+++ b/frontend/src/pages/Pending/index.jsx
@@ -1,9 +1,13 @@
-import React, { Component } from "react";
+import React from "react";
+import Logo from "../../assets/images/lah-logo-2.png";
 
-class Pending extends Component {
-  render() {
-    return <div>lets pretend we dont exist</div>;
-  }
-}
+import "./styles.scss";
+
+const Pending = () => (
+  <div className="pending">
+    <img id="lah-logo" src={Logo} alt="LAH Logo" />
+    <p>Your request is pending.</p>
+  </div>
+);
 
 export default Pending;

--- a/frontend/src/pages/Pending/index.jsx
+++ b/frontend/src/pages/Pending/index.jsx
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+
+// import Logo from "./images/lah-logo.png";
+
+import "./styles.scss";
+
+class Pending extends Component {
+  render() {
+    return <div>lets pretend we dont exist</div>;
+  }
+}
+
+export default Pending;

--- a/frontend/src/pages/Pending/styles.scss
+++ b/frontend/src/pages/Pending/styles.scss
@@ -1,0 +1,19 @@
+.pending {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #f9f9f9;
+
+  #lah-logo {
+    height: 10vmin;
+  }
+
+  p {
+    font-family: "Roboto";
+    font-weight: 700;
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
 * add new page, Pending
 * redirect based on role

<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status:
🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Redirect users to a screening page when the user successfully authenticates, but does not yet have a volunteer or admin role.

Fixes #134 

## Todos

In the future, we'll need to handle the case in which a user is rejected.

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![pending_page](https://user-images.githubusercontent.com/20096090/74881394-da0d5b00-5332-11ea-9f1a-c40e278f7e8f.gif)