### PR TITLE
modal edit

### DIFF
--- a/frontend/src/components/Modal/index.jsx
+++ b/frontend/src/components/Modal/index.jsx
@@ -25,6 +25,7 @@ const LAHModal = props => {
   };
 
   const handleEditResource = async data => {
+    data.tags = data.tags.split(',').map(tag => tag.trim());
     await editAndRefreshResource(data, props.resource._id);
     props.closeModal();
   };
@@ -121,6 +122,16 @@ const LAHModal = props => {
                   defaultValue={props.resource.description}
                   className="modal-input-field modal-input-textarea"
                   rows="10"
+                  disabled={!props.editable}
+                />
+              </label>
+              <label className="modal-lab">
+                <p>Tags</p>
+                <input
+                  ref={register}
+                  name="tags"
+                  defaultValue={props.resource.tags.join(',')}
+                  className="modal-input-field"
                   disabled={!props.editable}
                 />
               </label>

--- a/frontend/src/components/Modal/index.jsx
+++ b/frontend/src/components/Modal/index.jsx
@@ -130,7 +130,7 @@ const LAHModal = props => {
                 <input
                   ref={register}
                   name="tags"
-                  defaultValue={props.resource.tags.join(',')}
+                  defaultValue={props.resource.tags.join(', ')}
                   className="modal-input-field"
                   disabled={!props.editable}
                 />


### PR DESCRIPTION
## Status:
Allows tags to be edited for a resource. Modal displays them in a comma separated list and then takes input list, splits by comma, and trims each tag of whitespace before posting to backend (as shown in example).
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #136 

## Screenshots
Editing:
![image](https://user-images.githubusercontent.com/18370633/74696945-e40e4d00-51be-11ea-8fc5-1293606e0d95.png)
Once edited:
![image](https://user-images.githubusercontent.com/18370633/74696995-04d6a280-51bf-11ea-936e-c6c4c428d75c.png)

