### PR TITLE
Prevent navbar from rendering twice

### DIFF
--- a/frontend/src/components/PrivateRoute/index.jsx
+++ b/frontend/src/components/PrivateRoute/index.jsx
@@ -16,7 +16,6 @@ function PrivateRoute({
   const pending = role === roleEnum.PENDING;
   return (
     <div>
-      {authed && !pending && <Navbar />}
       <Route
         {...rest}
         render={props => {
@@ -25,7 +24,12 @@ function PrivateRoute({
           }
           if (authed === true) {
             if (!pending) {
-              return <Component {...props} />;
+              return (
+                <div>
+                  {authed && !pending && <Navbar />}
+                  <Component {...props} />
+                </div>
+              );
             }
             return <Pending {...props} />;
           }


### PR DESCRIPTION
* only render the navbar along with the component we want
* only renders when authenticated and not pending

:partyparrot:

## Status:

:rocket:

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #173 



