### PR TITLE
added user filter option 'all', made it default

### DIFF
--- a/frontend/src/pages/AdminView/index.jsx
+++ b/frontend/src/pages/AdminView/index.jsx
@@ -28,6 +28,7 @@ const UserManager = props => {
       <div className="manager-header">
         <h1>User Directory</h1>
         <select onChange={onCategoryChange} defaultValue={props.filter}>
+          <option value={userFilterEnum.ALL}>All Users</option>
           <option value={userFilterEnum.ACTIVE}>Active Users</option>
           <option value={userFilterEnum.PENDING}>Pending Users</option>
           <option value={userFilterEnum.REJECTED}>

--- a/frontend/src/redux/reducers/users.js
+++ b/frontend/src/redux/reducers/users.js
@@ -1,5 +1,6 @@
 import { UPDATE_USERS, CHANGE_USER_FILTER } from "../actions/users";
-const users = (state = [], action) => {
+import { userFilterEnum } from "../../utils/enums";
+const users = (state = { userFilterType: userFilterEnum.ALL }, action) => {
   switch (action.type) {
     case UPDATE_USERS:
       return { ...state, userList: action.payload };

--- a/frontend/src/redux/selectors/users.js
+++ b/frontend/src/redux/selectors/users.js
@@ -11,21 +11,18 @@ export const filteredUserSelector = createSelector(
     if (!users) {
       return [];
     }
-    if (!filter) {
-      return users.filter(
-        user => user.role === roleEnum.VOLUNTEER || user.role === roleEnum.ADMIN
-      );
-    }
     switch (filter) {
+      case userFilterEnum.ACTIVE:
+        return users.filter(
+          user =>
+            user.role === roleEnum.VOLUNTEER || user.role === roleEnum.ADMIN
+        );
       case userFilterEnum.REJECTED:
         return users.filter(user => user.role === roleEnum.REJECTED);
       case userFilterEnum.PENDING:
         return users.filter(user => user.role === roleEnum.PENDING);
       default:
-        return users.filter(
-          user =>
-            user.role === roleEnum.VOLUNTEER || user.role === roleEnum.ADMIN
-        );
+        return users;
     }
   }
 );

--- a/frontend/src/utils/enums.js
+++ b/frontend/src/utils/enums.js
@@ -6,6 +6,7 @@ const roleEnum = {
 };
 
 const userFilterEnum = {
+  ALL: "ALL",
   ACTIVE: "ACTIVE",
   PENDING: "PENDING",
   REJECTED: "REJECTED"


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status:

:rocket: Ready
<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->
This fix adds an option to the user filter categories in the admin panel, option "ALL". This filter is default now and just displays all users.

Fixes #146