### PR TITLE
Jab/resource type split

### DIFF
--- a/backend/models/Resource.js
+++ b/backend/models/Resource.js
@@ -2,6 +2,11 @@
  */
 const mongoose = require("mongoose");
 
+const resourceEnum = {
+  GROUP: "GROUP",
+  INDIVIDUAL: "INDIVIDUAL"
+};
+
 const Resource = new mongoose.Schema({
   companyName: { type: String, required: true },
   contactName: { type: String, required: true },
@@ -15,7 +20,13 @@ const Resource = new mongoose.Schema({
   },
   federalRegion: { type: Number, default: 0 },
   notes: { type: String },
-  tags: { type: Array, default: [] }
+  tags: { type: Array, default: [] },
+  type: {
+    type: String,
+    enum: [resourceEnum.GROUP, resourceEnum.INDIVIDUAL],
+    required: true
+  }
 });
 
 module.exports = mongoose.model("Resource", Resource);
+module.exports.resourceEnum = resourceEnum;

--- a/backend/models/Resource.js
+++ b/backend/models/Resource.js
@@ -24,7 +24,7 @@ const Resource = new mongoose.Schema({
   type: {
     type: String,
     enum: [resourceEnum.GROUP, resourceEnum.INDIVIDUAL],
-    required: true
+    default: resourceEnum.GROUP
   }
 });
 

--- a/backend/routes/api/resources.js
+++ b/backend/routes/api/resources.js
@@ -23,6 +23,7 @@ const {
   requireAdminStatus,
   requireVolunteerStatus
 } = require("../../utils/auth-middleware");
+const { resourceEnum } = require("../../models/Resource");
 
 const router = express.Router();
 
@@ -100,7 +101,8 @@ router.post(
           .items(Joi.number())
       }).default({ type: "Point", coordinates: [0, 0] }),
       notes: Joi.string().allow(""),
-      tags: Joi.array().items(Joi.string())
+      tags: Joi.array().items(Joi.string()),
+      type: Joi.string().default(resourceEnum.GROUP)
     })
   }),
   errorWrap(async (req, res) => {
@@ -174,7 +176,8 @@ router.put(
           .items(Joi.number())
       }),
       notes: Joi.string(),
-      tags: Joi.array().items(Joi.string())
+      tags: Joi.array().items(Joi.string()),
+      type: Joi.string()
     }),
     params: {
       resource_id: Joi.objectId().required()

--- a/backend/test/resource.test.js
+++ b/backend/test/resource.test.js
@@ -78,7 +78,7 @@ describe("GET /resources", () => {
       .get(`/api/resources`)
       .expect(200);
     expect(res.body.result).to.have.lengthOf(1);
-    expect(Object.keys(res.body.result[0])).to.have.lengthOf(11);
+    expect(Object.keys(res.body.result[0])).to.have.lengthOf(12);
     expect(didCheckIsVolunteer()).to.be.true;
   });
 });

--- a/backend/test/resource.test.js
+++ b/backend/test/resource.test.js
@@ -5,6 +5,7 @@ const Resource = require("../models/Resource");
 const { didCheckIsAdmin, didCheckIsVolunteer } = require("./auth_stubs");
 const sinon = require("sinon");
 const resourceUtils = require("../utils/resource-utils");
+const { resourceEnum } = require("../models/Resource");
 
 const sampleResourceInfo = {
   companyName: "Google",
@@ -16,7 +17,8 @@ const sampleResourceInfo = {
   location: {
     coordinates: [35, 40]
   },
-  tags: ["tech"]
+  tags: ["tech"],
+  type: resourceEnum.GROUP
 };
 
 const sampleResourceInfo2 = {
@@ -29,7 +31,8 @@ const sampleResourceInfo2 = {
   location: {
     coordinates: [40, 40]
   },
-  tags: ["social"]
+  tags: ["social"],
+  type: resourceEnum.INDIVIDUAL
 };
 
 const sampleResourceInfo3 = {
@@ -42,7 +45,8 @@ const sampleResourceInfo3 = {
   location: {
     coordinates: [40, 40]
   },
-  tags: ["social"]
+  tags: ["social"],
+  type: resourceEnum.INDIVIDUAL
 };
 
 const createSampleResource = async (resourceInfo = sampleResourceInfo) => {

--- a/frontend/src/components/Modal/ResourceModal/index.jsx
+++ b/frontend/src/components/Modal/ResourceModal/index.jsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { connect } from "react-redux";
 import { Button } from "reactstrap";
 import { openModal, closeModal } from "../../../redux/actions/modal";
-import { modalEnum } from "../../../utils/enums";
+import { modalEnum, resourceEnum } from "../../../utils/enums";
 import {
   editAndRefreshResource,
   addAndRefreshResource,
@@ -44,6 +44,8 @@ const ResourceModal = props => {
     setDeleteClicked(false);
     return deleteAndRefreshResource(props.resource._id);
   };
+
+  const makeOption = option => <option>{option}</option>;
 
   return (
     <div className="modal-wrap-ee">
@@ -121,6 +123,20 @@ const ResourceModal = props => {
                 className="modal-input-field"
                 disabled={!props.editable}
               />
+            </label>
+            <label className="modal-lab">
+              <p>Type</p>
+              <select
+                ref={register}
+                name="type"
+                defaultValue={props.resource.type}
+                className="modal-select-field"
+                disabled={!props.editable}
+              >
+                {Object.values(resourceEnum).map(
+                  makeOption
+                ) /* Enum to options */}
+              </select>
             </label>
             <label className="modal-lab">
               <p>Address</p>

--- a/frontend/src/utils/enums.js
+++ b/frontend/src/utils/enums.js
@@ -5,7 +5,7 @@ const roleEnum = {
   REJECTED: "REJECTED"
 };
 
-const resourceType = {
+const resourceEnum = {
   GROUP: "GROUP",
   INDIVIDUAL: "INDIVIDUAL"
 };
@@ -22,6 +22,6 @@ const modalEnum = {
 };
 
 module.exports.roleEnum = roleEnum;
-module.exports.resourceType = resourceType;
+module.exports.resourceEnum = resourceEnum;
 module.exports.userFilterEnum = userFilterEnum;
 module.exports.modalEnum = modalEnum;

--- a/frontend/src/utils/enums.js
+++ b/frontend/src/utils/enums.js
@@ -5,6 +5,11 @@ const roleEnum = {
   REJECTED: "REJECTED"
 };
 
+const resourceType = {
+  GROUP: "GROUP",
+  INDIVIDUAL: "INDIVIDUAL"
+};
+
 const userFilterEnum = {
   ACTIVE: "ACTIVE",
   PENDING: "PENDING",
@@ -17,5 +22,6 @@ const modalEnum = {
 };
 
 module.exports.roleEnum = roleEnum;
-module.exports.modalEnum = modalEnum;
+module.exports.resourceType = resourceType;
 module.exports.userFilterEnum = userFilterEnum;
+module.exports.modalEnum = modalEnum;


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status:

:rocket: Ready
<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->
Adds a new field to the resource model in frontend/backend: "type". This is one of two values, `GROUP` or `INDIVIDUAL`. By default it is group. Added enums to frontend/backend, added joi validation in backend API endpoints to account for this field. Added functionality to change this on the frontend as well.

Fixes #190 