### PR TITLE
add validation and styling to indicate when the resource form is filled properly

### DIFF
--- a/frontend/cypress/integration/directory.spec.js
+++ b/frontend/cypress/integration/directory.spec.js
@@ -24,7 +24,13 @@ context("Directory View", () => {
     cy.get('[name="companyName"]').type("Test Resource");
 
     cy.get("#submit-form-button").click();
-    cy.get(".Toastify__toast-body").should("contain.text", "Fail");
+    cy.get('[name="contactName"]').should("have.class", "invalid");
+
+    cy.get('[name="contactPhone"]').type("123-456-7890");
+
+    cy.get("#submit-form-button").click();
+    cy.get('[name="contactName"]').should("have.class", "invalid");
+    cy.get('[name="contactPhone"]').should("not.have.class", "invalid");
 
     // Don't close out of the modal on error
     cy.get(".modal-title").should("be.visible");

--- a/frontend/src/components/Modal/ResourceModal/index.jsx
+++ b/frontend/src/components/Modal/ResourceModal/index.jsx
@@ -51,8 +51,6 @@ const ResourceModal = props => {
     return deleteAndRefreshResource(props.resource._id);
   };
 
-  const errorStyle = { border: "1px solid red" };
-
   return (
     <div className="modal-wrap-ee">
       {props.isOpen && props.modalType === modalEnum.RESOURCE && (
@@ -68,9 +66,10 @@ const ResourceModal = props => {
                 type="text"
                 name="companyName"
                 defaultValue={props.resource.companyName}
-                className="modal-input-field"
+                className={`modal-input-field ${
+                  errors.companyName ? "invalid" : ""
+                }`}
                 disabled={!props.editable}
-                style={errors.companyName && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -80,9 +79,10 @@ const ResourceModal = props => {
                 type="text"
                 name="contactName"
                 defaultValue={props.resource.contactName}
-                className="modal-input-field"
+                className={`modal-input-field ${
+                  errors.contactName ? "invalid" : ""
+                }`}
                 disabled={!props.editable}
-                style={errors.contactName && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -92,9 +92,10 @@ const ResourceModal = props => {
                 type="text"
                 name="contactPhone"
                 defaultValue={props.resource.contactPhone}
-                className="modal-input-field"
+                className={`modal-input-field ${
+                  errors.contactPhone ? "invalid" : ""
+                }`}
                 disabled={!props.editable}
-                style={errors.contactPhone && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -104,9 +105,10 @@ const ResourceModal = props => {
                 type="text"
                 name="contactEmail"
                 defaultValue={props.resource.contactEmail}
-                className="modal-input-field"
+                className={`modal-input-field ${
+                  errors.contactEmail ? "invalid" : ""
+                }`}
                 disabled={!props.editable}
-                style={errors.contactEmail && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -115,10 +117,11 @@ const ResourceModal = props => {
                 ref={register({ required: true })}
                 name="description"
                 defaultValue={props.resource.description}
-                className="modal-input-field modal-input-textarea"
+                className={`modal-input-field modal-input-textarea ${
+                  errors.description ? "invalid" : ""
+                }`}
                 rows="10"
                 disabled={!props.editable}
-                style={errors.description && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -129,7 +132,7 @@ const ResourceModal = props => {
                 defaultValue={
                   props.isAddingResource ? "" : props.resource.tags.join(", ")
                 }
-                className="modal-input-field"
+                className={`modal-input-field ${errors.tags && "invalid"}`}
                 disabled={!props.editable}
               />
             </label>
@@ -140,9 +143,8 @@ const ResourceModal = props => {
                 name="address"
                 type="text"
                 defaultValue={props.resource.address}
-                className="modal-input-field"
+                className={`modal-input-field ${errors.address && "invalid"}`}
                 disabled={!props.editable}
-                style={errors.address && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -151,10 +153,11 @@ const ResourceModal = props => {
                 ref={register({ required: true })}
                 name="notes"
                 defaultValue={props.resource.notes}
-                className="modal-input-field modal-input-textarea"
                 rows="5"
+                className={`modal-input-field modal-input-textarea ${
+                  errors.notes ? "invalid" : ""
+                }`}
                 disabled={!props.editable}
-                style={errors.notes && errorStyle}
               />
             </label>
             {props.editable && (

--- a/frontend/src/components/Modal/ResourceModal/index.jsx
+++ b/frontend/src/components/Modal/ResourceModal/index.jsx
@@ -25,13 +25,19 @@ const ResourceModal = props => {
   };
 
   const handleEditResource = async data => {
-    data.tags = data.tags.split(",").map(tag => tag.trim());
+    data.tags = data.tags
+      .split(",")
+      .filter(t => t)
+      .map(tag => tag.trim());
     await editAndRefreshResource(data, props.resource._id);
     props.closeModal();
   };
 
   const handleAddResource = async data => {
-    data.tags = data.tags.split(",").map(tag => tag.trim());
+    data.tags = data.tags
+      .split(",")
+      .filter(t => t)
+      .map(tag => tag.trim());
     await addAndRefreshResource(data);
     props.closeModal();
   };
@@ -44,6 +50,8 @@ const ResourceModal = props => {
     setDeleteClicked(false);
     return deleteAndRefreshResource(props.resource._id);
   };
+
+  const errorStyle = { border: "1px solid red" };
 
   return (
     <div className="modal-wrap-ee">
@@ -62,52 +70,55 @@ const ResourceModal = props => {
                 defaultValue={props.resource.companyName}
                 className="modal-input-field"
                 disabled={!props.editable}
+                style={errors.companyName && errorStyle}
               />
-              {/* errors will return when field validation fails  */}
-              {errors.companyName && <span>This field is required</span>}
             </label>
             <label className="modal-lab">
               <p>Contact Name</p>
               <input
-                ref={register}
+                ref={register({ required: true })}
                 type="text"
                 name="contactName"
                 defaultValue={props.resource.contactName}
                 className="modal-input-field"
                 disabled={!props.editable}
+                style={errors.contactName && errorStyle}
               />
             </label>
             <label className="modal-lab">
               <p>Contact Phone</p>
               <input
-                ref={register}
+                ref={register({ required: true })}
                 type="text"
                 name="contactPhone"
                 defaultValue={props.resource.contactPhone}
                 className="modal-input-field"
                 disabled={!props.editable}
+                style={errors.contactPhone && errorStyle}
               />
             </label>
             <label className="modal-lab">
               <p>Contact Email</p>
               <input
-                ref={register}
+                ref={register({ required: true })}
                 type="text"
                 name="contactEmail"
                 defaultValue={props.resource.contactEmail}
                 className="modal-input-field"
                 disabled={!props.editable}
+                style={errors.contactEmail && errorStyle}
               />
             </label>
             <label className="modal-lab">
               <p>Description</p>
               <textarea
-                ref={register}
+                ref={register({ required: true })}
                 name="description"
                 defaultValue={props.resource.description}
                 className="modal-input-field modal-input-textarea"
                 rows="10"
                 disabled={!props.editable}
+                style={errors.description && errorStyle}
               />
             </label>
             <label className="modal-lab">
@@ -125,23 +136,25 @@ const ResourceModal = props => {
             <label className="modal-lab">
               <p>Address</p>
               <input
-                ref={register}
+                ref={register({ required: true })}
                 name="address"
                 type="text"
                 defaultValue={props.resource.address}
                 className="modal-input-field"
                 disabled={!props.editable}
+                style={errors.address && errorStyle}
               />
             </label>
             <label className="modal-lab">
               <p>Notes</p>
               <textarea
-                ref={register}
+                ref={register({ required: true })}
                 name="notes"
                 defaultValue={props.resource.notes}
                 className="modal-input-field modal-input-textarea"
                 rows="5"
                 disabled={!props.editable}
+                style={errors.notes && errorStyle}
               />
             </label>
             {props.editable && (

--- a/frontend/src/components/Modal/styles.scss
+++ b/frontend/src/components/Modal/styles.scss
@@ -41,6 +41,14 @@
   font-size: 15px;
 }
 
+.modal-input-field.invalid {
+  transition: all 0.3s;
+  border: 1.5px solid rgb(255, 190, 190);
+}
+.modal-input-field.invalid:focus {
+  border: solid red 1.5px;
+}
+
 .modal-input-field:focus {
   border: solid #f7922f 1.5px;
 }


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status: :rocket:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Validate fields and look angry if they're wrong.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #175 



## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots
![valid](https://user-images.githubusercontent.com/20096090/76260725-74700880-6226-11ea-815c-e53b14861a45.gif)
<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
