### PR TITLE
Disabled search until loader stops

### DIFF
--- a/frontend/src/pages/DirectoryView/SearchBar/index.jsx
+++ b/frontend/src/pages/DirectoryView/SearchBar/index.jsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { connect } from "react-redux";
 import { Button } from "reactstrap";
 import { useForm } from "react-hook-form";
 import { filterAndRefreshResource } from "../../../utils/api";
 
 import "../styles.scss";
 
-const SearchBar = () => {
+const SearchBar = ({ isLoading }) => {
   const { register, handleSubmit } = useForm();
   const onSubmit = data => {
     filterAndRefreshResource(data.keyword, data.location, data.tag);
@@ -37,6 +38,7 @@ const SearchBar = () => {
           id="search-button"
           type="submit"
           onSubmit={e => e.preventDefault()}
+          disabled={isLoading}
         >
           SEARCH
         </Button>
@@ -45,4 +47,8 @@ const SearchBar = () => {
   );
 };
 
-export default SearchBar;
+const mapStateToProps = state => ({
+  isLoading: state.isLoading
+});
+
+export default connect(mapStateToProps)(SearchBar);


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status:
🚀 
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Workaround for #200, open to alternate solutions!
Disables search while an API request is currently loading to prevent a race condition where the user tries searching while the current request is still waiting for a response and that request returns faster.
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #200

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
