### PR TITLE
set tab indices for search inputs and buttons

### DIFF
--- a/frontend/src/pages/MapView/SearchBar/index.jsx
+++ b/frontend/src/pages/MapView/SearchBar/index.jsx
@@ -32,8 +32,14 @@ const SearchBar = () => {
               ref={register}
               type="text"
               placeholder="Location"
+              tabIndex="0"
             />
-            <Button className="closeButtons" close onClick={clearLocation} />
+            <Button
+              className="closeButtons"
+              close
+              onClick={clearLocation}
+              tabIndex="-1"
+            />
           </div>
         </div>
         <div className="searchKeyword">
@@ -46,8 +52,14 @@ const SearchBar = () => {
               ref={register}
               list="suggestionsList"
               placeholder="Search"
+              tabIndex="0"
             />
-            <Button className="closeButtons" close onClick={clearSearch} />
+            <Button
+              className="closeButtons"
+              close
+              onClick={clearSearch}
+              tabIndex="-1"
+            />
           </div>
           <button className="submitSearch" type="submit">
             Go


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->

## Status: :rocket:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
On the map page, in the search box, when the user is typing in the Location input, hitting Tab would go to the "x" close button instead of the next input box.

This PR adds the tabIndex property to those elements to remove the close buttons from the tab-able DOM elements.
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #197